### PR TITLE
Add mission GUI and translate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,37 @@
-# Toolkit MATLAB — Preliminary Rocket Design (Multi‑Estágio + Gravity Turn)
+# MATLAB Toolkit — Preliminary Rocket Design (Multi-Stage + Gravity Turn)
 
-**Idioma:** Português (PT-PT)  
-**Objetivo:** Estimar massas, dimensões e *payload ratio* para foguetões multi‑estágio, incluindo simulação de *gravity turn* 2D e iteração simples entre **trajetória** e **configuração**.
+**Language:** English  
+**Purpose:** Estimate masses, dimensions and payload ratio for multi-stage rockets, including a 2D gravity turn simulation and simple iteration between **trajectory** and **configuration**.
 
-> ⚠️ **Nota importante**: Estes modelos são preliminares/simplificados e usam aproximações (atmosfera exponencial, arrasto constante por estágio, controlo de *pitch* simplificado, queima por estágios em série, sem boosters laterais). São úteis para *trade‑offs* iniciais e sensibilidades, **não** para verificação de voo.
+> ⚠️ **Important note:** These models are preliminary/simplified and rely on approximations (exponential atmosphere, constant drag per stage, simplified pitch control, sequential stage burns without side boosters). They are useful for initial trade-offs and sensitivity studies, **not** for flight verification.
 
-## Como usar
-1. Abrir o `main.m` no MATLAB/Octave.
-2. Escolher a configuração em `main.m` (e.g., `demo_config` ou criar uma em `configs/`).
-3. Executar o `main.m`. O script vai:
-   - Carregar a configuração do lançador e parâmetros de missão.
-   - Otimizar (por defeito) a trajetória básica (tempo do *pitch* e *kick*).
-   - Procurar, por bisseção, a **carga útil máxima** que ainda atinge a órbita-alvo.
-   - Reportar o *payload ratio* (= m_payload / m0) e gráficos de altitude/velocidade.
+## How to use
+1. Open `main.m` in MATLAB/Octave.
+2. Choose the configuration in `main.m` (e.g., `demo_config` or create one in `configs/`).
+3. Run `main.m`. The script will:
+   - Show a small GUI asking for the desired payload mass and target orbit altitude.
+   - Load the launcher configuration and mission parameters.
+   - Optimize (by default) the basic trajectory (pitch timing and kick).
+   - Search, by bisection, for the **maximum payload** that still reaches the target orbit.
+   - Report the payload ratio (= m_payload / m0) and provide altitude/velocity plots.
 
-## Pastas
-- `configs/` — ficheiros com parâmetros por lançador (ex.: `demo_config.m`).  
-  Crie variantes (ex.: `vega_config.m`, `protonkdm3_config.m`, `ariane5_config.m`) editando *Isp*, *thrust*, massas estruturais, massas de propelente, `CdA`, etc.
-- `util/` — funções auxiliares.
+## Folders
+- `configs/` — parameter files for each launcher (e.g., `demo_config.m`).  
+  Create variants (e.g., `vega_config.m`, `protonkdm3_config.m`, `ariane5_config.m`) by editing Isp, thrust, structural masses, propellant masses, `CdA`, etc.
+- `util/` — helper functions.
 
-## Limitações principais
-- ISA simplificada (exponencial, altura de escala fixa).
-- Arrasto modelado via `CdA` constante por estágio.
-- Direção do impulso: vertical até `t_pitch`; janela curta de *pitch kick*; depois *gravity turn* com *thrust* alinhado com a velocidade.
-- Sem modelação de boosters laterais/acoplagens assimétricas.
-- Otimização *sem* toolboxes (usa *grid search* e `fminsearch` quando aplicável).
+## Main limitations
+- Simplified ISA (exponential, fixed scale height).
+- Drag modeled via constant `CdA` per stage.
+- Thrust direction: vertical until `t_pitch`; short pitch-kick window; then gravity turn with thrust aligned with velocity.
+- No modeling of side boosters/asymmetric attachments.
+- Optimization *without* toolboxes (uses grid search and `fminsearch` when applicable).
 
-## Resultados esperados
-- Estimativa de massa de descolagem, *payload ratio* e histórico temporal (altitude, velocidade, ângulo).
-- Base para comparar configurações (alterando ficheiros em `configs/`) e fazer *what‑if* nos parâmetros.
+## Expected results
+- Estimate of lift-off mass, payload ratio and time histories (altitude, velocity, angle).
+- Basis to compare configurations (by editing files in `configs/`) and perform parameter what-if analyses.
 
 ---
+This toolkit stems from the author's Master's thesis available at: <https://fenix.tecnico.ulisboa.pt/cursos/meaer/dissertacao/2353642467857>.
 
-Diogo, ajusta livremente as configurações (Isp, empuxos, fracções estruturais, massas de propelente, `CdA`) com os dados da tua tese — os nomes de campos estão comentados para corresponder a práticas correntes.
+Diogo, feel free to adjust the configurations (Isp, thrust levels, structural fractions, propellant masses, `CdA`) with data from your thesis — field names are commented to match common practices.

--- a/main.m
+++ b/main.m
@@ -1,45 +1,63 @@
-% MAIN — Toolkit de Dimensionamento Preliminar de Foguetões (MATLAB/Octave)
-% Diogo: edita a configuração e os parâmetros abaixo conforme o teu projeto.
+% MAIN — Preliminary Rocket Design Toolkit (MATLAB/Octave)
+% Adjust the configuration and parameters below as needed.
 
 clear; clc; close all;
 addpath('configs'); addpath('util');
 
-%% Parâmetros de missão (exemplo)
-mission.target_alt   = 200e3;     % Altitude de órbita alvo [m]
-mission.inclination  = 0.0;       % [rad] — neste modelo 2D não é usado
-mission.launch_lat   = deg2rad(38.65); % Latitude do local de lançamento (ex.: Lisboa ~ 38.65ºN)
-mission.east_azimuth = 0;         % 0 => Este; neste 2D assumimos voo para Este
+% Ask user for payload and orbit via GUI
+prompt   = {'Desired payload mass [kg]', 'Target orbit altitude [km]'};
+dlgtitle = 'Mission setup';
+definput = {'1000', '200'};
+answer   = inputdlg(prompt, dlgtitle, 1, definput);
+if isempty(answer)
+    error('User cancelled input dialog.');
+end
+user_payload = str2double(answer{1});
+user_orbit_km = str2double(answer{2});
 
-% Otimização de trajetória — limites de pesquisa
+%% Mission parameters
+mission.target_alt   = user_orbit_km * 1e3; % Target orbit altitude [m]
+mission.inclination  = 0.0;       % [rad] — not used in this 2D model
+mission.launch_lat   = deg2rad(38.65); % Launch site latitude (e.g., Lisbon ~ 38.65ºN)
+mission.east_azimuth = 0;         % 0 => East; in this 2D model we assume flight to the East
+
+% Trajectory optimization — search bounds
 traj_bounds.t_pitch_s     = [5, 100];     % [s]
 traj_bounds.pitch_kick_deg= [0.5, 12];    % [deg]
-traj_bounds.kick_dur_s    = [0.5, 3.0];   % [s] duração do impulso inclinado
+traj_bounds.kick_dur_s    = [0.5, 3.0];   % [s] duration of the inclined impulse
 
-% Critério de corte para "órbita atingida"
-mission.tol_v_ms   = 50;     % tolerância em velocidade orbital [m/s]
-mission.tol_gamma  = deg2rad(2); % tolerância em ângulo de trajetória [rad]
+% Orbit attainment tolerance criteria
+mission.tol_v_ms   = 50;     % orbital velocity tolerance [m/s]
+mission.tol_gamma  = deg2rad(2); % trajectory angle tolerance [rad]
 
-%% Escolher configuração
-% Substitui por outro ficheiro em /configs (ex.: 'vega_config', 'protonkdm3_config', 'ariane5_config')
+%% Choose configuration
+% Replace with another file in /configs (e.g., 'vega_config', 'protonkdm3_config', 'ariane5_config')
 cfg = demo_config();
 
-%% Otimização de trajetória + bisseção da carga útil máxima
-% Nota: a massa de propelente por estágio vem de cfg.stages(i).mp (edita na config)
+%% Trajectory optimization + bisection of maximum payload
+% Note: propellant mass per stage comes from cfg.stages(i).mp (edit in the config)
 opt_opts.verbose = true;
 
 [result, history] = evaluate_payload_ratio(cfg, mission, traj_bounds, opt_opts);
 
-%% Relatório
-fprintf('\n===== RESULTADOS =====\n');
-fprintf('Payload máximo: %.2f kg\n', result.payload_kg);
-fprintf('Massa de descolagem m0: %.2f kg\n', result.m0_kg);
+% Check if desired payload is achievable
+if user_payload <= result.payload_kg
+    fprintf('Desired payload %.2f kg CAN be delivered to %.0f km orbit.\n', user_payload, mission.target_alt/1e3);
+else
+    fprintf('Desired payload %.2f kg exceeds capability %.2f kg for %.0f km orbit.\n', user_payload, result.payload_kg, mission.target_alt/1e3);
+end
+
+%% Report
+fprintf('\n===== RESULTS =====\n');
+fprintf('Maximum payload: %.2f kg\n', result.payload_kg);
+fprintf('Lift-off mass m0: %.2f kg\n', result.m0_kg);
 fprintf('Payload ratio (m_PL/m0): %.4f\n', result.payload_ratio);
 fprintf('t_pitch: %.2f s | pitch_kick: %.2f deg | kick_dur: %.2f s\n', ...
     result.traj.t_pitch, rad2deg(result.traj.pitch_kick), result.traj.kick_dur);
 
-%% Gráficos
+%% Plots
 plot_trajectory(history.best_traj);
 
-%% Guardar resultados em MAT
+%% Save results to MAT
 save('last_run.mat', 'result', 'history');
-disp('Resultados guardados em last_run.mat');
+disp('Results saved to last_run.mat');


### PR DESCRIPTION
## Summary
- Translate README to English and reference originating thesis
- Add GUI prompt in `main.m` to collect payload mass and target orbit

## Testing
- `octave -qf main.m` *(fails: command not found)*
- `matlab -batch "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af28431c788324bfea0032b893dab0