### PR TITLE
Add component heuristics for mass and volume estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@
   Create variants (e.g., `vega_config.m`, `protonkdm3_config.m`, `ariane5_config.m`) by editing Isp, thrust, structural masses, propellant masses, `CdA`, etc.
 - `util/` — helper functions.
 
+### Component heuristics
+`util/component_heuristics.m` provides quick estimates for basic hardware:
+
+```matlab
+ms = estimate_engine_mass(1.0e6);             % massa do motor para 1 MN
+vol = estimate_tank_volume(50e3, 1000);       % volume para 50 t a 1000 kg/m^3
+```
+These helpers are used in `demo_config.m` to populate structural mass,
+propellant volume and structural fraction automatically.
+
 ## Main limitations
 - Simplified ISA (exponential, fixed scale height).
 - Drag modeled via constant `CdA` per stage.

--- a/configs/demo_config.m
+++ b/configs/demo_config.m
@@ -8,7 +8,9 @@ function cfg = demo_config()
 %   .Isp_s      — impulso específico [s]
 %   .thrust_N   — empuxo constante [N] durante a queima
 %   .fs_struct  — fração estrutural (m_struct / (m_struct + m_prop))
+%   .ms_kg      — massa estrutural [kg] (motor + tanque)
 %   .mp_kg      — massa de propelente [kg]
+%   .volume_m3  — volume estimado do tanque [m^3]
 %   .CdA_m2     — coef. de arrasto x área de referência [m^2]
 %
 % NOTA: Para casos com 3-4 estágios, adicionar mais entradas ao vetor.
@@ -18,19 +20,23 @@ cfg.notes = 'Modelo simplificado, sem boosters.';
 
 % Estágio 1 (valores meramente ilustrativos)
 s1.name      = 'Stage 1';
-s1.Isp_s     = 280;          % s  (sólido ou líquido de baixa altitude)
-s1.thrust_N  = 2.0e6;        % N
-s1.fs_struct = 0.08;         % m_struct / (m_struct + m_prop)
-s1.mp_kg     = 120e3;        % kg
-s1.CdA_m2    = 4.0;          % m^2
+s1.Isp_s     = 280;           % s  (sólido ou líquido de baixa altitude)
+s1.thrust_N  = 2.0e6;         % N
+s1.ms_kg     = estimate_engine_mass(s1.thrust_N);
+s1.mp_kg     = 30 * s1.ms_kg; % heurística: m_prop ~ 30x m_motor
+s1.fs_struct = s1.ms_kg / (s1.ms_kg + s1.mp_kg);
+s1.volume_m3 = estimate_tank_volume(s1.mp_kg, 1800); % densidade típica de propelente sólido
+s1.CdA_m2    = 4.0;           % m^2
 
 % Estágio 2
 s2.name      = 'Stage 2';
-s2.Isp_s     = 330;          % s (líquido)
-s2.thrust_N  = 600e3;        % N
-s2.fs_struct = 0.10;         %
-s2.mp_kg     = 30e3;         % kg
-s2.CdA_m2    = 2.0;          % m^2
+s2.Isp_s     = 330;           % s (líquido)
+s2.thrust_N  = 600e3;         % N
+s2.ms_kg     = estimate_engine_mass(s2.thrust_N);
+s2.mp_kg     = 25 * s2.ms_kg; % heurística: m_prop ~ 25x m_motor
+s2.fs_struct = s2.ms_kg / (s2.ms_kg + s2.mp_kg);
+s2.volume_m3 = estimate_tank_volume(s2.mp_kg, 1000); % densidade típica de propelente líquido
+s2.CdA_m2    = 2.0;           % m^2
 
 cfg.stages = [s1, s2];
 end

--- a/util/component_heuristics.m
+++ b/util/component_heuristics.m
@@ -1,0 +1,18 @@
+function m_engine_kg = estimate_engine_mass(thrust_N)
+% ESTIMATE_ENGINE_MASS  Heurística simples para massa do motor [kg].
+%   Assume relação empuxo/peso típica de 50.
+%   thrust_N  - empuxo do motor [N]
+%   m_engine_kg - massa estimada [kg]
+
+T_W = 50;           % relação empuxo/peso típica
+g0 = 9.80665;       % gravidade ao nível do mar [m/s^2]
+m_engine_kg = thrust_N / (T_W * g0);
+end
+
+function volume_m3 = estimate_tank_volume(propellant_mass_kg, density_kgm3)
+% ESTIMATE_TANK_VOLUME  Volume aproximado do tanque [m^3].
+%   propellant_mass_kg - massa de propelente [kg]
+%   density_kgm3       - densidade do propelente [kg/m^3]
+
+volume_m3 = propellant_mass_kg / density_kgm3;
+end


### PR DESCRIPTION
## Summary
- add `estimate_engine_mass` and `estimate_tank_volume` helper functions
- compute demo configuration masses and tank volumes via heuristics
- document component heuristics usage in README

## Testing
- `octave --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, preventing install)*

------
https://chatgpt.com/codex/tasks/task_e_68b233f9f53c83249b41d8ff65fc5309