### PR TITLE
feat: support multiple orbit types

### DIFF
--- a/main.m
+++ b/main.m
@@ -1,33 +1,49 @@
 function main(varargin)
 % MAIN — Preliminary Rocket Design Toolkit (MATLAB/Octave)
-%   MAIN(PAYLOAD, ORBIT_ALT) runs the design for the specified payload
-%   mass [kg] and target orbit altitude [km]. When called with no inputs it
-%   prompts the user via a GUI dialog.
+%   MAIN(PAYLOAD, ORBIT) runs the design for the specified payload mass
+%   [kg] and target ORBIT structure. When called with no inputs it prompts
+%   the user via a GUI dialog to select orbit type and parameters.
 
 clc; close all;
 
 % Parse optional inputs
 parser = inputParser;
 addOptional(parser, 'payload', []);
-addOptional(parser, 'orbit_alt', []);
+addOptional(parser, 'orbit', struct());
 parse(parser, varargin{:});
 
-payload   = parser.Results.payload;
-orbit_alt = parser.Results.orbit_alt;
+payload = parser.Results.payload;
+orbit   = parser.Results.orbit;
 
 % If arguments were not supplied, fall back to GUI dialog
-if nargin < 2 || isempty(payload) || isempty(orbit_alt)
-    prompt   = {'Desired payload mass [kg]', 'Target orbit altitude [km]'};
+if isempty(payload) || ~isfield(orbit, 'type')
+    prompt   = {'Desired payload mass [kg]', 'Orbit type (circular/elliptic)'};
     dlgtitle = 'Mission setup';
-    definput = {'1000', '200'};
+    definput = {'1000', 'circular'};
     answer   = inputdlg(prompt, dlgtitle, 1, definput);
     if isempty(answer)
         error('User cancelled input dialog.');
     end
-    payload   = str2double(answer{1});
-    orbit_alt = str2double(answer{2});
+    payload = str2double(answer{1});
+    orbtype = lower(strtrim(answer{2}));
+    switch orbtype
+        case 'circular'
+            prm = inputdlg({'Target orbit altitude [km]'}, 'Orbit parameters', 1, {'200'});
+            if isempty(prm), error('User cancelled input dialog.'); end
+            orbit.type = 'circular';
+            orbit.altitude_km = str2double(prm{1});
+        case {'elliptic','elliptical','eliptica','elíptica'}
+            prm = inputdlg({'Periapsis altitude [km]', 'Apoapsis altitude [km]'}, 'Orbit parameters', 1, {'200','500'});
+            if isempty(prm), error('User cancelled input dialog.'); end
+            orbit.type = 'elliptic';
+            orbit.periapsis_km = str2double(prm{1});
+            orbit.apoapsis_km = str2double(prm{2});
+        otherwise
+            error('Unknown orbit type.');
+    end
 end
 
+mission.orbit = orbit;
 
-run_design(payload, orbit_alt);
+run_design(payload, mission);
 end

--- a/util/evaluate_payload_ratio.m
+++ b/util/evaluate_payload_ratio.m
@@ -99,18 +99,20 @@ end
 end
 
 function ok = reaches_orbit(traj, mission)
-% Verifica critério de órbita: altitude >= target_alt, velocidade ~ v_circ e gamma ~ 0
-env = earth_constants();
-r_target = env.Re + mission.target_alt;
-v_circ   = sqrt(env.mu / r_target);
+% Verifica critério de órbita de acordo com o tipo selecionado
+cond = orbit_conditions(mission.orbit);
+target_alt = cond.altitude_m;
 
 % encontrar o instante em que h cruza target_alt (ou o ponto mais alto)
-idx = find(traj.h >= mission.target_alt, 1, 'first');
+idx = find(traj.h >= target_alt, 1, 'first');
 if isempty(idx)
     [~, idx] = max(traj.h);
 end
 
-v_err = abs(traj.v(idx) - v_circ);
+v_err = abs(traj.v(idx) - cond.velocity_ms);
 g_err = abs(traj.gamma(idx));
-ok = (traj.h(idx) >= mission.target_alt) && (v_err <= mission.tol_v_ms) && (g_err <= mission.tol_gamma);
+ok = (traj.h(idx) >= target_alt) && (v_err <= mission.tol_v_ms) && (g_err <= mission.tol_gamma);
+if ~isempty(cond.apoapsis_m)
+    ok = ok && (max(traj.h) >= cond.apoapsis_m);
+end
 end

--- a/util/orbit_conditions.m
+++ b/util/orbit_conditions.m
@@ -1,0 +1,32 @@
+function cond = orbit_conditions(orbit)
+%ORBIT_CONDITIONS Compute target altitude and velocity for orbit insertion.
+%   COND = ORBIT_CONDITIONS(ORBIT) returns a structure with fields:
+%       altitude_m   - target altitude where velocity must match [m]
+%       velocity_ms  - required orbital velocity at that altitude [m/s]
+%       apoapsis_m   - desired apoapsis altitude [m] (only for elliptic)
+%
+%   ORBIT.type = 'circular' with field .altitude_km
+%                'elliptic' with fields .periapsis_km and .apoapsis_km
+%
+%   Uses Earth constants from earth_constants().
+
+env = earth_constants();
+
+switch lower(orbit.type)
+    case 'circular'
+        cond.altitude_m = orbit.altitude_km * 1e3;
+        r = env.Re + cond.altitude_m;
+        cond.velocity_ms = sqrt(env.mu / r);
+        cond.apoapsis_m = [];
+    case {'elliptic','elliptical'}
+        rp = env.Re + orbit.periapsis_km * 1e3;
+        ra = env.Re + orbit.apoapsis_km * 1e3;
+        a = 0.5 * (rp + ra);
+        cond.altitude_m = orbit.periapsis_km * 1e3;
+        cond.velocity_ms = sqrt(env.mu * (2/rp - 1/a));
+        cond.apoapsis_m = orbit.apoapsis_km * 1e3;
+    otherwise
+        error('Unknown orbit type %s', orbit.type);
+end
+end
+


### PR DESCRIPTION
## Summary
- add orbit type selection and parameter prompts in main
- accept orbit details in run_design and describe orbits in output
- compute orbital conditions for circular and elliptic cases
- check orbit attainment using orbit_conditions

## Testing
- `octave -qf --eval "addpath('util'); orbit_conditions(struct('type','circular','altitude_km',200))"` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b233ff698483249e816a52118d029e